### PR TITLE
Use registry embed codes

### DIFF
--- a/index.md
+++ b/index.md
@@ -545,7 +545,7 @@ Buttons are designed to not be preset with any colour. If your product uses a sp
 
 These buttons have hollow colouring and are the default for standard button interactions.
 
-<iframe width="100%" frameborder='0' scrolling='no' src='http://build.origami.ft.com/files/o-ft-buttons/demos/individual.html'></iframe>
+<iframe style='width:100%' frameborder='0' scrolling='no' src='http://registry.origami.ft.com/components/o-buttons@1.8.1/demos/visual/demos/individual.html?embed=1'></iframe>
 
 
 
@@ -553,20 +553,20 @@ These buttons have hollow colouring and are the default for standard button inte
 
 These buttons are only used for pages which require affirmative action. Examples would be on marketing pages, product purchasing pages, sign-up pages and as sign-in buttons.
 
-<iframe width="100%" frameborder='0' scrolling='no' src='http://build.origami.ft.com/files/o-ft-buttons/demos/individual-standout.html?embed=1'></iframe>
+<iframe style='width:100%' frameborder='0' scrolling='no' src='http://registry.origami.ft.com/components/o-buttons@1.8.1/demos/visual/demos/individual-standout.html?embed=1'></iframe>
 
 ####Pagination
 
 Used for paging through content. e.g. search results. There are two scales depending on whether you're creating something for touch or not.
 
-<iframe width="100%" frameborder='0' scrolling='no' src='http://build.origami.ft.com/files/o-ft-buttons/demos/pagination.html?embed=1'></iframe>
+<iframe style='width:100%' frameborder='0' scrolling='no' src='http://registry.origami.ft.com/components/o-buttons@1.8.1/demos/visual/demos/pagination.html?embed=1'></iframe>
 
 
 ####Toggle buttons / multi toggle
 
 Simple on / off interactions will use the following design.
 
-<iframe width="100%" frameborder='0' scrolling='no' src='http://build.origami.ft.com/files/o-ft-buttons/demos/grouped.html?embed=1'></iframe>
+<iframe style='width:100%' frameborder='0' scrolling='no' src='http://registry.origami.ft.com/components/o-buttons@1.8.1/demos/visual/demos/grouped.html?embed=1'></iframe>
 
 ##Forms
 


### PR DESCRIPTION
It would be nice if the UI style guide used the embed code offered by the registry to embed demos.  This has recently been implemented so that the embed code pops up in an overlay and is easy to copy and paste into your page:

![image](https://cloud.githubusercontent.com/assets/1735391/6581833/4fd38e72-c751-11e4-950d-123c2f2a09bf.png)

This PR swaps out the buttons demos which were loading direct from the build service, for embed widgets powered by the registry.

I know there was a concern about how heavy the frame of the embed was, so we've made it more subtle - hopefully this addresses those concerns while still ensuring the demo links back to the right registry page.

This is what it looks like in the UI style guide:

![image](https://cloud.githubusercontent.com/assets/1735391/6581908/d4306a28-c751-11e4-89d9-6c167cacdb19.png)
